### PR TITLE
Fix: Replace non-standard H2 separator in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ An Electron-based desktop application for Perplexity AI.
 - Cross-platform compatibility
 
 
-=======
+---
 ## Building and Running
 
 Each application can be built and run independently:


### PR DESCRIPTION
I replaced a `=======` line, likely a remnant of a Setext-style H2 heading or a merge artifact, with a standard Markdown horizontal rule (`---`) for better compatibility and rendering.